### PR TITLE
折线图出现断点情况 #155

### DIFF
--- a/src/main/webapp/org/cboard/service/chart/chartLineService.js
+++ b/src/main/webapp/org/cboard/service/chart/chartLineService.js
@@ -25,6 +25,8 @@ cBoard.service('chartLineService', function () {
             var sum = 0;
             for (var i = 0; i < aggregate_data.length; i++) {
                 sum += aggregate_data[i][j] ? Number(aggregate_data[i][j]) : 0;
+                // change undefined to 0
+                aggregate_data[i][j] = aggregate_data[i][j] ? Number(aggregate_data[i][j]) : 0;
             }
             sum_data[j] = sum;
         }


### PR DESCRIPTION
解决因为折线图返回数据为undefined导致折线断点的情况。
将undefined替换成0
