### PR TITLE
解决China Map 在同个dashboard中不支持多个实例的bug #120

### DIFF
--- a/src/main/webapp/org/cboard/util/CBoardMapRender.js
+++ b/src/main/webapp/org/cboard/util/CBoardMapRender.js
@@ -14,7 +14,7 @@ var CBoardMapRender = function (jqContainer, options) {
 
 CBoardMapRender.prototype.do = function (tall, persist) {
     this.tall = tall;
-    this.container = $('.map_wrapper');
+    this.container = this.jqContainer;
     tall = _.isUndefined(tall) ? 500 : tall;
     var args = {
         height: tall,


### PR DESCRIPTION
解决China Map 在同个dashboard中不支持多个实例的bug
