### PR TITLE
加入列类型描述

### DIFF
--- a/src/main/resources/mapper/UserDao.xml
+++ b/src/main/resources/mapper/UserDao.xml
@@ -3,9 +3,16 @@
 <mapper namespace="org.cboard.dao.UserDao">
 
     <update id="save">
-        <![CDATA[
-        INSERT INTO dashboard_user(user_id,login_name,user_name,user_password,user_status) VALUES (#{userId},#{loginName},#{userName},#{userPassword},#{userStatus, jdbcType=VARCHAR})
-        ]]>
+        INSERT INTO dashboard_user(user_id,login_name,user_name,user_password,user_status) VALUES (#{userId},#{loginName},#{userName},#{userPassword},
+            <choose>
+                <when test="userStatus == null">
+                    null
+                </when>
+                <otherwise>
+                    #{userStatus}
+                 </otherwise>
+            </choose>        
+        )
     </update>
 
     <select id="getUserList" resultType="org.cboard.pojo.DashboardUser">

--- a/src/main/resources/mapper/UserDao.xml
+++ b/src/main/resources/mapper/UserDao.xml
@@ -4,7 +4,7 @@
 
     <update id="save">
         <![CDATA[
-        INSERT INTO dashboard_user(user_id,login_name,user_name,user_password,user_status) VALUES (#{userId},#{loginName},#{userName},#{userPassword},#{userStatus})
+        INSERT INTO dashboard_user(user_id,login_name,user_name,user_password,user_status) VALUES (#{userId},#{loginName},#{userName},#{userPassword},#{userStatus, jdbcType=VARCHAR})
         ]]>
     </update>
 


### PR DESCRIPTION
目前使用的是oracle数据库，在新建用户时，执行insert会报“无效的列类型”错误。
原因：未对userStatus字段赋值，mybatis向数据库的某字段insert空值（NULL）时，会报这个错误。
解决：在mapper的对应位置改为以下形式即可。

修改前：
> #{userStatus}

修改后：
> #{userStatus, jdbcType=VARCHAR}