### PR TITLE
对于没有被赋予编辑修改图表权限的用户隐藏【编辑】按钮 等4个问题

### DIFF
--- a/src/main/java/org/cboard/services/BoardService.java
+++ b/src/main/java/org/cboard/services/BoardService.java
@@ -53,6 +53,7 @@ public class BoardService {
         for (Object row : rows) {
             JSONObject o = (JSONObject) row;
             if ("param".equals(o.getString("type"))) {
+                layout.put("containsParam", true);
                 continue;
             }
             JSONArray widgets = o.getJSONArray("widgets");

--- a/src/main/webapp/org/cboard/view/cboard/homepage.html
+++ b/src/main/webapp/org/cboard/view/cboard/homepage.html
@@ -1,4 +1,4 @@
-<section class="content-header">
+<section class="content-header" ng-if="isShowMenu('config.widget')">
     <h1>
         {{'HOMEPAGE.TITLE'|translate}}
         <small>{{'HOMEPAGE.QUICK_START'|translate}}</small>
@@ -7,7 +7,7 @@
         <li><a href=""><i class="fa fa-dashboard"></i> {{'HOMEPAGE.LINK_CAPTION'|translate}}</a></li>
     </ol>
 </section>
-    <div id="inner-container" class="content">
+    <div id="inner-container" class="content" ng-if="isShowMenu('config.widget')">
         <div class="row">
             <div class="col-md-4">
                 <div class="box box-solid">

--- a/src/main/webapp/org/cboard/view/dashboard/layout/header.html
+++ b/src/main/webapp/org/cboard/view/dashboard/layout/header.html
@@ -4,7 +4,7 @@
         {{board.name}}
     </h1>
     <div class="breadcrumb" style="cursor: pointer" >
-        <div style="display: inline-block">
+        <div style="display: inline-block" ng-if="board.layout.containsParam" >
             <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"><i class="fa fa-filter"></i> {{"COMMON.PARAM" | translate}}
                 <span class="fa fa-caret-down"></span>
             </button>
@@ -39,7 +39,7 @@
                 <span ng-show="exportStatus"><i class="fa fa-spinner fa-spin"></i> Loading</span>
             </button>
         </div>
-        <div style="display: inline-block" ng-click="editBoard()">
+        <div style="display: inline-block" ng-click="editBoard()" ng-if="isShowMenu('config.widget')">
             <button class="btn btn-primary btn-sm">
                 <span><i class="fa fa-edit"></i>&nbsp;{{"COMMON.EDIT" | translate}}</span>
             </button>

--- a/src/main/webapp/starter/main-header.html
+++ b/src/main/webapp/starter/main-header.html
@@ -18,7 +18,7 @@
             <!-- User Account Menu -->
             <li class="dropdown user user-menu">
                 <!-- Menu Toggle Button -->
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown">
                     <!-- The user image in the navbar-->
                     <img src="{{user.avatar}}" class="user-image">
                     <!-- hidden-xs hides the username on small devices so only the image appears. -->


### PR DESCRIPTION
问题1：对于没有被赋予编辑修改图表权限的用户，
在看板查看图表时，隐藏相应图表位置的【编辑】按钮

问题2：对于没有添加参数行的面板，
在面板展示的时候，隐藏右上角的【条件】按钮

问题3：解决【在首页之外的其他页面点击右上角的用户按钮都会自动跳回首页】的问题

问题4：对于未持有编辑图表权限的用户，在首页对其隐藏【图表快速编辑】项目