### PR TITLE
FIX: #554 维度过滤条件设置为{userRoles}，结果不正确

### DIFF
--- a/src/main/java/org/cboard/dao/RoleDao.java
+++ b/src/main/java/org/cboard/dao/RoleDao.java
@@ -15,6 +15,8 @@ public interface RoleDao {
 
     List<DashboardRole> getRoleList(String userId);
 
+    List<DashboardRole> getCurrentRoleList(String userId);
+
     List<DashboardRole> getRoleListAll();
 
     int update(DashboardRole role);

--- a/src/main/java/org/cboard/services/RoleService.java
+++ b/src/main/java/org/cboard/services/RoleService.java
@@ -3,6 +3,7 @@ package org.cboard.services;
 import org.cboard.dao.RoleDao;
 import org.cboard.pojo.DashboardRole;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,6 +15,9 @@ import java.util.List;
 public class RoleService {
 
     public static final String RES_BOARD = "board";
+
+    @Value("${admin_user_id}")
+    private String adminUserId;
 
     @Autowired
     private RoleDao roleDao;
@@ -28,6 +32,10 @@ public class RoleService {
 
     public List<DashboardRole> getCurrentRoleList(){
         String userid = authenticationService.getCurrentUser().getUserId();
-        return roleDao.getRoleList(userid);
+        if (userid.equals(adminUserId)) {
+            return roleDao.getRoleListAll();
+        }
+
+        return roleDao.getCurrentRoleList(userid);
     }
 }

--- a/src/main/resources/mapper/RoleDao.xml
+++ b/src/main/resources/mapper/RoleDao.xml
@@ -17,6 +17,13 @@
         order by role_name
     </select>
 
+    <select id="getCurrentRoleList" resultType="org.cboard.pojo.DashboardRole">
+        SELECT r.role_id roleId,r.role_name roleName,ur.user_id userId 
+        FROM dashboard_role r left join dashboard_user_role ur on ur.role_id=r.role_id 
+        where ur.user_id = #{0}
+        order by r.role_name
+    </select>
+
     <select id="getRoleListAll" resultType="org.cboard.pojo.DashboardRole">
         SELECT role_id roleId,role_name roleName,user_id userId FROM dashboard_role
         order by role_name


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
修复 #554 问题

### What type of PR is it?
[Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring]
Bug Fix

### Todos


### What is the Github issue?
* Open an issue on Github https://github.com/yzhang921/CBoard/issues
* Put link here, and add [- #ISSUE_NUMBER] in PR title
Fix: 维度过滤条件设置为{userRoles}，结果不正确 #554 

### How should this be tested?
Outline the steps to test the PR here.
1.  新建任意图表W，设置数据集
2. 添加维度D，设置维度D过滤条件为=当前用户角色{userRoles}
3. 新建看板K，添加图表W
4. 给任意非admin用户U设置看板K的查看权限
5. 登录用户U，查看看板K，应该只能看到维度D = 用户U角色的数据。

### Screenshots (if appropriate)

### Questions:
* Is there breaking changes for older versions?
* Does this needs documentation?
Bug fix，不需要更新文档